### PR TITLE
Added a couple more error strings to check for

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
-# Fix ConnectWise Automate Service in Linux
+# Fix ConnectWise Automate (formerly LabTech) Service in Linux
 
 Scenario:
-Automate may report a Linux box offline, and restarting the service may not
-  address the issue. You may find in **/usr/local/ltechagent/agent.log**
-  an error message stating **Failed to unencrypt LabTech agent password.**
-  Removing the state files in **/usr/local/ltechagent/** and restarting the
-  service will typically address it. This script will check the end of the
-  **agent.log** and see if the error message is there. If so, it will restart
-  the agent and clear the state files. You can also run this on a schedule.
+Automate may report a Linux server/workstation offline, and restarting the
+  service may not address the issue. You may find in
+  `/usr/local/ltechagent/agent.log` an error message stating one of the
+  following:
+
+    <error> 12/06/2020 13:13:13 (agent.c:635) Failed to unencrypt LabTech agent password.
+    <error> 12/06/2020 13:13:13 (agent.c:490) Failed to read state file /usr/local/ltechagent/state. Trying to read the backup.
+    <error> 12/06/2020 13:13:13 (agent.c:495) Failed to read old state file /usr/local/ltechagent/state_old
+
+Removing the state files in `/usr/local/ltechagent/` and restarting the
+  service will typically address it. This script will check the `tail` end of the
+  `agent.log` and see if the error message is there. If so, it will restart
+  the agent and delete the state files. You can also run this on a schedule.
 
 Getting Started
 ---------------
@@ -22,7 +28,6 @@ To install as a systemd timer (five minutes after boot and hourly afterwards),
 If you rather just run this manually:
 
     sudo ./clear-ltechagent-state
-
 
 There may be other reasons as to why the agent is running. This is only meant
   to address the scenario listed above. These scripts are not provided by

--- a/clear-ltechagent-state
+++ b/clear-ltechagent-state
@@ -1,13 +1,15 @@
 #!/bin/bash
 # Written by Dennis Cole III
 # Clear LTechAgent State on Linux
-# This script checks for "Failed to unencrypt LabTech agent password".
+# This script checks for "Failed to unencrypt LabTech agent password",
+# "Failed to read agent state file" and "Failed to read old agent state file"
+#
 # If found, it deletes the state files in the ltechagent folder and restarts
 # agent.
 # This can be run as a regular script
 # This script is not written by, nor supported by ConnectWise
 #
-# Version 0.1.3
+# Version 0.2.1 - added additional error strings to check
 
 
 # Check if running as root and exit if not
@@ -39,7 +41,9 @@ AGENT_LOG="$LTDIR/agent.log"
 STATE_FILE="$LTDIR/state"
 STATE_OLD_FILE="$LTDIR/state_old"
 LTSVC="ltechagent.service"
-ERROR_CHECK_STRING="Failed to unencrypt LabTech agent password."
+ERROR_CHECK_STRINGS=("Failed to unencrypt LabTech agent password."
+                    "Failed to read agent state file"
+                    "Failed to read old agent state file")
 
 # Trying to verify if LTechAgent is installed
 if [[ ! -d $LTDIR ]]
@@ -59,10 +63,13 @@ AGENT_ISSUE_FOUND=false
 
 while read -r line
 do
-  if [[ "$line" == *"$ERROR_CHECK_STRING"* ]]
-  then
-    AGENT_ISSUE_FOUND=true
-  fi
+  for e in ${ERROR_CHECK_STRINGS[@]}
+  do
+    if [[ "$line" == *"$e"* ]]
+    then
+      AGENT_ISSUE_FOUND=true
+    fi
+  done
 done < <(tail $AGENT_LOG)
 
 if [[ "$AGENT_ISSUE_FOUND" == "true" ]]
@@ -85,7 +92,7 @@ then
   systemctl start $LTSVC
   check_fail $?
 else
-  echo "The error string $ERROR_CHECK_STRING was not found."
+  echo "No recent errors were found that can be fixed with this script."
   echo "If you are still having an issue, you may need to do addtional troubleshooting"
 fi
 


### PR DESCRIPTION
Found that there were two more errors in the `agent.log` that explicitly check to read the state files. Removing the state files works as well in that scenario.